### PR TITLE
[代转] 根据fg官方文档，域名更换至hub.fastgit.xyz，特此修改。同时cnpm无法使用，无法解析。原因未知，屏蔽。

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ const pkg = require(path.resolve(__dirname, 'package.json'));
 const GH_ADDR_MATCH_REG = /(https?:\/\/github\.com)(\/.*\/)+([^\/]+\.git)/;
 const GH_TEST_REG = /https?:\/\/github\.com\/.*.git/;
 const MIRROR_DICT = {
-  cnpm: 'https://github.com.cnpmjs.org',
+//  cnpm: 'https://github.com.cnpmjs.org',
   gitee: 'https://gitee.com/mirrors',
   gitclone: 'https://gitclone.com/github.com',
-  fastgit: 'https://hub.fastgit.org',
+  fastgit: 'https://hub.fastgit.xyz',
   github: 'https://github.com',
 };
 const MIRROR_LIST = Object.keys(MIRROR_DICT);
@@ -19,7 +19,7 @@ const MIRROR_LIST = Object.keys(MIRROR_DICT);
 program
   .version(pkg.version)
   .allowUnknownOption()
-  .option('-cn --cnpm', 'cnpmjs镜像(默认)')
+  //.option('-cn --cnpm', 'cnpmjs镜像(默认)')
   .option('-fa --fastgit', 'fastgit镜像')
   .option('-ge --gitee', 'gitee镜像')
   .option('-gc --gitclone', 'gitclone镜像')


### PR DESCRIPTION
提交记录：[根据fg官方文档，域名更换至hub.fastgit.xyz，特此修改。同时cnpm无法使用，无法解析。原因未知，屏蔽。
](https://gitee.com/OtherCopy/wogit/commit/f81fc22b5a93796ed72258dfa937074bc91cb071)

修改人：[小k](https://gitee.com/cs_xiaok)